### PR TITLE
cl-som-imx7: Backport PMIC update

### DIFF
--- a/board/compulab/cl-som-imx7/cl-som-imx7.c
+++ b/board/compulab/cl-som-imx7/cl-som-imx7.c
@@ -667,10 +667,10 @@ int power_init_board(void)
 	if (ret)
 		return ret;
 
-	/* set DDR_1_5V to 1.225V */
+	/* set DDR_1_5V to 1.35V */
 	pmic_reg_read(p, PFUZE3000_SW3VOLT, &reg);
 	reg &= ~0x0f;
-	reg |= PFUZE3000_SW3_SETP(12250);
+	reg |= PFUZE3000_SW3_SETP(13500);
 	ret = pmic_reg_write(p, PFUZE3000_SW3VOLT, reg);
 	if (ret)
 		return ret;

--- a/board/compulab/cl-som-imx7/cl-som-imx7.c
+++ b/board/compulab/cl-som-imx7/cl-som-imx7.c
@@ -651,26 +651,26 @@ int power_init_board(void)
 	if (ret)
 		return ret;
 
-	/* set VDD_ARM_IN to 1.350V */
+	/* set VDD_ARM_IN to 1.225V */
 	pmic_reg_read(p, PFUZE3000_SW1AVOLT, &reg);
 	reg &= ~0x3f;
-	reg |= PFUZE3000_SW1AB_SETP(13500);
+	reg |= PFUZE3000_SW1AB_SETP(12250);
 	ret = pmic_reg_write(p, PFUZE3000_SW1AVOLT, reg);
 	if (ret)
 		return ret;
 
-	/* set VDD_SOC_IN to 1.350V */
+	/* set VDD_SOC_IN to 1.225V */
 	pmic_reg_read(p, PFUZE3000_SW1BVOLT, &reg);
 	reg &= ~0x3f;
-	reg |= PFUZE3000_SW1AB_SETP(13500);
+	reg |= PFUZE3000_SW1AB_SETP(12250);
 	ret = pmic_reg_write(p, PFUZE3000_SW1BVOLT, reg);
 	if (ret)
 		return ret;
 
-	/* set DDR_1_5V to 1.350V */
+	/* set DDR_1_5V to 1.225V */
 	pmic_reg_read(p, PFUZE3000_SW3VOLT, &reg);
 	reg &= ~0x0f;
-	reg |= PFUZE3000_SW3_SETP(13500);
+	reg |= PFUZE3000_SW3_SETP(12250);
 	ret = pmic_reg_write(p, PFUZE3000_SW3VOLT, reg);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Hello,

My kernel (5.10) stops booting after bumping to HAB 1.3.1 and the commit 0d5ef5d5c387733d37263ce43589921b07b9a2a9.

This PR backports the commits 1bdcaf4297e9a519c6dbc4f5ebf74b7bae75ab9e and f0a96805bc8452aabb2cc23fdd0dc1d0528ad7e8 from the dev branch (2017.07).

The kernel is now booting again.